### PR TITLE
Major version release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 2
+    reviewers:
+      - amimart
+      - ccamel
+    assignees:
+      - amimart
+      - ccamel
+  - package-ecosystem: github-actions
+    directory: /src
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 2
+    reviewers:
+      - amimart
+      - ccamel
+    assignees:
+      - amimart
+      - ccamel

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,15 @@
+name: Auto merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge-dependabot:
+    runs-on: ubuntu-22.04
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Auto merge PR
+        uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.OKP4_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           yarn build && yarn package
 
       - name: Release project
+        id: semantic
         uses: cycjimmy/semantic-release-action@v3.2.0
         with:
           semantic_version: 19.0.2
@@ -54,3 +55,9 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+
+      - name: Push updates to branch for major version
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: 'git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           yarn build && yarn package
 
       - name: Release project
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3.2.0
         with:
           semantic_version: 19.0.2
           branch: main


### PR DESCRIPTION
This PR is to publish a branch named `vX` where `X` is the major version so that it's possible to use the action like this : 

```
uses: okp4/follow-contributor-action@v1
```
Like it's usually possible with github actions.

Implementing the workaround, waiting for this https://github.com/semantic-release/semantic-release/issues/1515 to be merged.

Also set dependabot auto merge and update cycjimmy/semantic-release-action  